### PR TITLE
mingw-cross: Remove C++11 use in windeployqt patch

### DIFF
--- a/mingw-cross/0001-windeployqt-Hack-to-use-objdump-for-PE-parsing.patch
+++ b/mingw-cross/0001-windeployqt-Hack-to-use-objdump-for-PE-parsing.patch
@@ -85,7 +85,7 @@ index a29b38b..dcf9bb3 100644
 +
 +    QStringList libs;
 +    QByteArray prefix("\tDLL Name: ");
-+    for (const QByteArray &line : output.split('\n'))
++    foreach (const QByteArray &line, output.split('\n'))
 +        libs << QString::fromLatin1(line.mid(prefix.size()).trimmed());
 +
 +    // XXX Assuming 32bit

--- a/mingw-cross/README.md
+++ b/mingw-cross/README.md
@@ -14,6 +14,8 @@ mingw32-filesystem mingw32-crt mingw32-headers mingw32-bintuils mingw32-cpp ming
 mingw32-pkg-config mingw32-zlib-static mingw32-winpthreads-static
 ```
 
+The `0001-windeployqt-Hack-to-use-objdump-for-PE-parsing.patch` patch assumes a 32bit release build, and assumes that compiler library DLLs are in `/usr/i686-w64-mingw32/sys-root/mingw/bin/`. If these aren't true, you should modify the patch. A better solution is needed here.
+
 Build dependencies
 ------------------
 


### PR DESCRIPTION
Fixes #3 