### PR TITLE
osx: Patch tor's configure to work around a macOS SDK bug

### DIFF
--- a/osx/build-deps.sh
+++ b/osx/build-deps.sh
@@ -49,17 +49,18 @@ cd ..
 cd libevent
 git clean -dfx .
 git reset --hard
+git apply "${ROOT_SRC}/../osx/libevent-0001-Forcefully-disable-clock_gettime-on-macOS-due-to-a-S.patch"
 ./autogen.sh
-./configure --prefix="${ROOT_LIB}/libevent" --disable-openssl
+CFLAGS="-mmacosx-version-min=10.7" ./configure --prefix="${ROOT_LIB}/libevent" --disable-openssl
 make ${MAKEOPTS}
 make install
 cd ..
-fi
 
 # Tor
 cd tor
 git clean -dfx .
 git reset --hard
+git apply "${ROOT_SRC}/../osx/tor-0001-Forcefully-disable-getentropy-and-clock_gettime-on-m.patch"
 ./autogen.sh
 CFLAGS="-fPIC -mmacosx-version-min=10.7" ./configure --prefix="${ROOT_LIB}/tor" --with-openssl-dir="${ROOT_LIB}/openssl/" --with-libevent-dir="${ROOT_LIB}/libevent/" --enable-static-openssl --enable-static-libevent --disable-asciidoc
 make ${MAKEOPTS}

--- a/osx/libevent-0001-Forcefully-disable-clock_gettime-on-macOS-due-to-a-S.patch
+++ b/osx/libevent-0001-Forcefully-disable-clock_gettime-on-macOS-due-to-a-S.patch
@@ -1,0 +1,33 @@
+From bd7817e3f0f5ea7b9188788f124471fc0223c251 Mon Sep 17 00:00:00 2001
+From: John Brooks <john.brooks@dereferenced.net>
+Date: Mon, 7 Nov 2016 21:29:58 -0700
+Subject: [PATCH] Forcefully disable clock_gettime on macOS due to a SDK bug
+
+clock_gettime were added in macOS 10.12, but the __OSX_AVAILABLE_STARTING
+macro was left off of the declaration in the SDK header, so the
+-mmacosx-version-min flag is ignored. This results in a libevent that links
+to symbols only available on 10.12 and later.
+
+A cleaner, possibly upstreamable fix would be to check whether
+(MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12) and skip this
+function test.
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index d42edd8..c616d8b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -289,7 +289,7 @@ AC_C_INLINE
+ AC_HEADER_TIME
+ 
+ dnl Checks for library functions.
+-AC_CHECK_FUNCS([gettimeofday vasprintf fcntl clock_gettime strtok_r strsep])
++AC_CHECK_FUNCS([gettimeofday vasprintf fcntl strtok_r strsep])
+ AC_CHECK_FUNCS([getnameinfo strlcpy inet_ntop inet_pton signal sigaction strtoll inet_aton pipe eventfd sendfile mmap splice arc4random arc4random_buf issetugid geteuid getegid getprotobynumber setenv unsetenv putenv sysctl])
+ AC_CHECK_FUNCS([umask])
+ 
+-- 
+2.10.0
+

--- a/osx/tor-0001-Forcefully-disable-getentropy-and-clock_gettime-on-m.patch
+++ b/osx/tor-0001-Forcefully-disable-getentropy-and-clock_gettime-on-m.patch
@@ -1,0 +1,40 @@
+From adf4cf4cb8c0e8c8753240d63aa6d68d70b8f20f Mon Sep 17 00:00:00 2001
+From: John Brooks <john.brooks@dereferenced.net>
+Date: Mon, 7 Nov 2016 21:21:13 -0700
+Subject: [PATCH] Forcefully disable getentropy and clock_gettime on macOS due
+ to a SDK bug
+
+getentropy and clock_gettime were added in macOS 10.12, but the
+__OSX_AVAILABLE_STARTING macro was left off of the declaration in the SDK
+header, so the -mmacosx-version-min flag is ignored. This results in a tor
+that links to symbols only available on 10.12 and later.
+
+A cleaner, possibly upstreamable fix would be to check whether
+(MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12) and skip these
+function tests.
+---
+ configure.ac | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 37827d6..e1b146a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -394,14 +394,12 @@ AC_CHECK_FUNCS(
+         accept4 \
+         backtrace \
+         backtrace_symbols_fd \
+-        clock_gettime \
+ 	eventfd \
+ 	explicit_bzero \
+ 	timingsafe_memcmp \
+         flock \
+         ftime \
+         getaddrinfo \
+-        getentropy \
+         getifaddrs \
+         getpass \
+         getrlimit \
+-- 
+2.10.0
+


### PR DESCRIPTION
See the patch for details, and https://github.com/ricochet-im/ricochet/issues/480

Incidentally, fix this script being broken due to a stray 'fi'